### PR TITLE
hiatus announcement and subsequent website changes

### DIFF
--- a/content/FAQ.md
+++ b/content/FAQ.md
@@ -6,9 +6,13 @@ showToc: true
 tocopen: true
 ---
 
+## VPupPr hiatus
+
+The main developer of vpuppr ([@Youwin](https://github.com/you-win)) has decided to take an official hiatus! Community forks of vpuppr may exist in the future for both godot versions (3.x and 4.x) so keep an eye out.
+
 ## I read the docs but still need help!
 
-Come join the [Discord](https://discord.gg/PeHR6Tjyvn)! The community can help you in real-time!
+Come join the [Discussion](https://github.com/virtual-puppet-project/vpuppr/discussions)! The community can help you in real-time!
 
 ## What is vpuppr?
 
@@ -17,14 +21,11 @@ It is most notable for tracking and rendering 3D Vtuber models.
 
 ## What are the supported platforms?
 
-vpuppr is currently supported on Windows and most common Linux distributions. OSX is not currently supported, however
-packaging vpuppr should be doable by following the
-[official Godot instructions](https://docs.godotengine.org/en/stable/tutorials/export/exporting_for_macos.html).
+vpuppr is currently supported on Windows and most common Linux distributions. OSX is not currently supported, however packaging vpuppr should be doable by following the [official Godot instructions](https://docs.godotengine.org/en/stable/tutorials/export/exporting_for_macos.html).
 
 ## How do I report an issue?
 
-Issues should be submitted on [GitHub](https://github.com/virtual-puppet-project/vpuppr/issues). Be sure to include
-your operating system, app version, logs, and any other related information.
+Issues should be submitted on [GitHub](https://github.com/virtual-puppet-project/vpuppr/issues). Be sure to include your operating system, app version, logs, and any other related information.
 
 ## How do I build from source?
 
@@ -32,9 +33,7 @@ vpuppr runs off a custom build of the Godot engine. Get a pre-compiled build of 
 
 ## Why is tracking is not responding?
 
-Please note it might take a second for tracking to activate. It _is_ trying to track your face! Also check that
-your face is well lit. Usually having a lamp above your desk is enough. If it's still not working, submit an issue
-and/or ask the Discord community!
+Please note it might take a second for tracking to activate. It _is_ trying to track your face! Also check that your face is well lit. Usually having a lamp above your desk is enough. If it's still not working, submit an issue and/or ask the Discussion board!
 
 ## Why is mouse tracking not included by default?
 
@@ -42,5 +41,5 @@ Simply put, it's a very niche use-case and is less preferable to real face track
 
 ## What engine is vpuppr using?
 
-Currently vpuppr runs on Godot 3.x with plans to port over to 4.x once Godot 4 becomes more stable.
+Currently vpuppr stable runs on Godot 3.x with 4.x in development but on hiatus for now. 
 

--- a/content/about.md
+++ b/content/about.md
@@ -8,7 +8,11 @@ Virtual Puppet Project, often shortened to vpuppr, aims to be an accessible, ope
 
 Found a problem with the program? Submit an [issue on GitHub](https://github.com/virtual-puppet-project/vpuppr/issues)!
 
-Feel free to join the [Discord](https://discord.gg/PeHR6Tjyvn) community to share your thoughts or help collaborate!
+Feel free to join the [Discussion](https://github.com/virtual-puppet-project/vpuppr/discussions) board to share your thoughts or help collaborate!
+
+### Announcement
+
+`In the interest of not getting anyone's hopes up, vpuppr's development is now indefinitely on hiatus. I am sorry for letting it drag on for as long as it did, and I am sorry I never got vpuppr to a state where it could actually be useful.` -Youwin (Creator of VPupPr)
 
 ### Contributors
 
@@ -20,4 +24,4 @@ Check out the people who helped build this!
 
 ## Demo
 
-Here's a quick demo from a slightly older alpha version by [ItsRogueRen](https://youtu.be/7K63acAQj7Q).
+Here's a quick demo from an older alpha version by [ItsRogueRen](https://youtu.be/7K63acAQj7Q).


### PR DESCRIPTION
With the announcement of the hiatus and closing of discord server, couple quick changes on the website to match plus all links to discord have been redirected to the discussion board